### PR TITLE
Sdk version bump & script to verify contract by address 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "export": "next export",
-    "deploy": "next build && next export && npx thirdweb@latest upload out"
+    "start": "node verify.mjs"
   },
   "dependencies": {
     "@thirdweb-dev/chains": "^0.1.27",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@thirdweb-dev/chains": "^0.1.27",
-    "@thirdweb-dev/sdk": "^3.10.28",
+    "@thirdweb-dev/sdk": "^4",
     "ethers": "^5"
   },
   "devDependencies": {

--- a/verify-custom.mjs
+++ b/verify-custom.mjs
@@ -1,0 +1,17 @@
+import { ThirdwebSDK } from "@thirdweb-dev/sdk";
+import { CronosBeta } from "@thirdweb-dev/chains" // Chain the contract you want to verify is on
+
+const sdk = new ThirdwebSDK(CronosBeta, {
+  clientId: "YOUR_CLIENT_ID", // Use client id if using on the client side, get it from dashboard settings
+  secretKey: "YOUR_SECRET_KEY", // Use secret key if using on the server, get it from dashboard settings
+});
+
+const explorerAPIUrl = ""; // e.g. https://api.etherscan.io/api
+const explorerAPIKey = ""; // Generate API key on the explorer
+const contractAddress = ""; // contract address to verify 
+
+await sdk.verifier.verifyContract(
+    contractAddress,
+    explorerAPIUrl,
+    explorerAPIKey,
+  );


### PR DESCRIPTION
1. Updated the sdk to use version `4^` to accept client Ids
2. Added [verify-custom.mjs](https://github.com/Yash094/thirdweb-Prebuilt-Verification/blob/main/verify-custom.mjs) to verify the contracts by address using the `verifyContract` method on the sdk
